### PR TITLE
refactor(filters): add generic filter class and serie comparator

### DIFF
--- a/codigo/src/main/java/CompareSerie.java
+++ b/codigo/src/main/java/CompareSerie.java
@@ -1,0 +1,8 @@
+import java.util.Comparator;
+
+public class CompareSerie implements Comparator<Serie> {
+    @Override
+    public int compare(Serie o1, Serie o2) {
+        return o1.getQuantidadeEpisodios().compareTo(o2.getQuantidadeEpisodios());
+    }
+}

--- a/codigo/src/main/java/FilterMediaSet.java
+++ b/codigo/src/main/java/FilterMediaSet.java
@@ -1,0 +1,16 @@
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class FilterMediaSet<Media> {
+    private Set<Media> items;
+
+    public FilterMediaSet(Set<Media> items) {
+        this.items = items;
+    }
+
+    public List<Media> filter(Predicate<Media> predicate) {
+        return items.stream().filter(predicate).collect(Collectors.toList());
+    }
+}

--- a/codigo/src/main/java/PlataformaStreaming.java
+++ b/codigo/src/main/java/PlataformaStreaming.java
@@ -34,17 +34,17 @@ public class PlataformaStreaming {
     }
 
     public List<Media> filtrarPorGenero(String genero) {
-        return midias.stream().filter(m -> m.getGenero().equals(genero)).collect(Collectors.toList());
+        return new FilterMediaSet<>(midias).filter(m -> m.getGenero().equals(genero));
     }
 
     public List<Media> filtrarPorIdioma(String idioma) {
-        return midias.stream().filter(m -> m.getIdioma().equals(idioma)).collect(Collectors.toList());
+        return new FilterMediaSet<>(midias).filter(m -> m.getIdioma().equals(idioma));
     }
 
     public List<Media> filtrarPorQtdEpisodios(int quantEpisodios) {
-        return midias.stream().filter(m -> m instanceof Serie && ((Serie) m).getQuantidadeEpisodios().equals(quantEpisodios)).collect(Collectors.toList());
-
+        return new FilterMediaSet<>(midias).filter(m -> m instanceof Serie && ((Serie) m).getQuantidadeEpisodios().equals(quantEpisodios));
     }
+
     public Media buscarMidia(String nome) {
         Optional<Media> midia = midias.stream().filter(m -> m.getNome().equals(nome)).findFirst();
 


### PR DESCRIPTION
perguntar pro Caram pfv 🙂:
- pq o comparator é ideal para filtrar as midias, se ele é melhor para ordenar? única forma que pensei seria checar se o compare é igual 0 no método filter. mesmo assim me parece inviável, pq ele recebe dois objetos como parametro, entao eu teria que declarar um objeto auxiliar - setado com os valores procurados - para comparar com os demais no filter
- por isso, de primeira, eu pensei em fazer uma classe que abstraia o método filter para evitar repetição de código